### PR TITLE
Added "PlotFTIR.lang" option per #10

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
 ^LICENSE$
+^paper$

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # PlotFTIR (development version)
 
+* Added ability to set default language in options() (#10) 
+
 # PlotFTIR 1.0.0
 
 * Initial Release & CRAN Submission.

--- a/R/plot_ftir.R
+++ b/R/plot_ftir.R
@@ -35,13 +35,20 @@
 #' @param lang An optional argument for language. If set to one of `fr`,
 #'   `french`, `francais`, or `français` the axis and default plot and legend
 #'   titles will change to french. If non-default legend or plot titles are
-#'   provided they are used as-is. Can also provide `en`, `english` or
-#'   `anglais`.
+#'   provided they are used as-is. You can also provide `en`, `english` or
+#'   `anglais`, or (the default) `NA` will use the default language from user
+#'   options. To set a permanent default, set `options("PlotFTIR.lang" = "en")`
+#'   or `options("PlotFTIR.lang" = "fr")` for English or French, respectively.
 #'
 #'   Un argument optionnel pour la langue. S'il vaut `Fr`, `French`, `Francais`,
 #'   ou `Français`, l'axe et les titres par défaut de le tracé et du légende
 #'   seront en français. Si des titres du légende ou de tracé autres que ceux
-#'   par défaut sont fournis, ils seront utilisés tels quels.
+#'   par défaut sont fournis, ils seront utilisés tels quels. Vous pouvez aussi
+#'   fournir `en`, `english` ou `anglais`, ou (le défaut) `NA` qui utilisera le
+#'   langue par défaut des options de l'utilisateur. Pour définir une valeur
+#'   par défaut permanente, mettez `options("PlotFTIR.lang" = "en")` ou
+#'   `options("PlotFTIR.lang" = "fr")` pour l'anglais ou le français,
+#'   respectivement.
 #'
 #' @keywords internal
 #'
@@ -71,7 +78,7 @@
 #'   marqueurs afin de mettre en évidence les nombres d'ondes importants, et
 #'   [move_plot_legend()] pour modifier la position de la légende.
 #'
-plot_ftir_core <- function(ftir, plot_title = "FTIR Spectra", legend_title = "Sample ID", lang = "en") {
+plot_ftir_core <- function(ftir, plot_title = "FTIR Spectra", legend_title = "Sample ID", lang = NA) {
   # Package Checks
   if (!requireNamespace("ggplot2", quietly = TRUE)) {
     cli::cli_abort(c("{.pkg PlotFTIR} requires {.pkg ggplot2} package installation.",
@@ -92,7 +99,15 @@ plot_ftir_core <- function(ftir, plot_title = "FTIR Spectra", legend_title = "Sa
     ))
   }
 
-  lang <- rlang::arg_match(lang, values = c("en", "english", "anglais", "fr", "french", "francais", "fran\u00e7ais"), multiple = FALSE)
+  # if language is provided, check against permitted, else use default from options
+  if(!is.na(lang)){
+    lang <- rlang::arg_match(lang,
+                             values = c("en", "english", "anglais", "fr", "french", "francais", "fran\u00e7ais"),
+                             multiple = FALSE)
+  } else {
+    lang <- getOption("PlotFTIR.lang", default = "en")
+  }
+
   l <- substr(lang, 0, 2)
   if (l == "fr") {
     if (all(plot_title == "FTIR Spectra")) {
@@ -184,7 +199,7 @@ plot_ftir_core <- function(ftir, plot_title = "FTIR Spectra", legend_title = "Sa
 #'   # Plot FTIR spectras stacked showing the differences in the `biodiesel` dataset
 #'   plot_ftir_stacked(biodiesel)
 #' }
-plot_ftir_stacked <- function(ftir, plot_title = "FTIR Spectra", legend_title = "Sample ID", stack_offset = 10, lang = "en") {
+plot_ftir_stacked <- function(ftir, plot_title = "FTIR Spectra", legend_title = "Sample ID", stack_offset = 10, lang = NA) {
   ftir <- check_ftir_data(ftir, "PlotFTIR::plot_ftir_stacked")
 
   if (!is.numeric(stack_offset) || length(stack_offset) > 1) {
@@ -246,7 +261,7 @@ plot_ftir_stacked <- function(ftir, plot_title = "FTIR Spectra", legend_title = 
 #'   # Plot a basic FTIR Spectra overlay from the `sample_spectra` data set with default titles
 #'   plot_ftir(sample_spectra)
 #' }
-plot_ftir <- function(ftir, plot_title = "FTIR Spectra", legend_title = "Sample ID", lang = "en") {
+plot_ftir <- function(ftir, plot_title = "FTIR Spectra", legend_title = "Sample ID", lang = NA) {
   ftir <- check_ftir_data(ftir, "PlotFTIR::plot_ftir_stacked")
   p <- plot_ftir_core(ftir = ftir, plot_title = plot_title, legend_title = legend_title, lang = lang)
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,5 @@
+# nocov start
+
 .onAttach <- function(libname, pkgname) {
   # default to memory cache if not set
   lang_option <- getOption("PlotFTIR.lang")
@@ -21,3 +23,4 @@
     }
   }
 }
+# nocov end

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,23 @@
+.onAttach <- function(libname, pkgname) {
+  # default to memory cache if not set
+  lang_option <- getOption("PlotFTIR.lang")
+
+  if (is.null(lang_option)) {
+    lang_option <- "en"
+    options("PlotFTIR.lang" = "en")
+    packageStartupMessage(
+      'Plotting spectra with PlotFTIR. Please cite if plots are used in publishing (`citation("plotFTIR")`).\n',
+      'PlotFTIR set to English as default. Changer au fran\u00e7ais par la fonction options("PlotFTIR.lang" = "en")'
+    )
+  } else {
+    if (tolower(lang_option) %in% c("fr", "fra", "french", "francais", "fran\u00e7ais")) {
+      packageStartupMessage(
+        'Trac\u00e9 des spectres avec PlotFTIR. Veuillez citer si les tracu00e9s sont utilisu00e9s dans un publication (`citation("plotFTIR")`).'
+      )
+    } else {
+      packageStartupMessage(
+        'Plotting spectra with PlotFTIR. Please cite if plots are used in publishing (`citation("plotFTIR")`).'
+      )
+    }
+  }
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,6 +13,7 @@ knitr::opts_chunk$set(
   dpi = 300
 )
 library(magrittr)
+library(PlotFTIR)
 ```
 
 # PlotFTIR <img src='man/figures/PlotFTIR_logo.png' align="right" width="25%" min-width="120px"/>
@@ -33,6 +34,8 @@ You can install the development version of `PlotFTIR` from [GitHub](https://gith
 ``` r
 # install.packages("devtools")
 devtools::install_github("NRCan/PlotFTIR")
+
+library(PlotFTIR)
 ```
 
 ## Example Plots
@@ -40,7 +43,6 @@ devtools::install_github("NRCan/PlotFTIR")
 This is a basic example which shows you how to plot a prepared set of FTIR spectra:
 
 ```{r basic_plot_en}
-library(PlotFTIR)
 biodiesel_plot <- plot_ftir(biodiesel)
 biodiesel_plot
 ```
@@ -177,6 +179,10 @@ Please cite this package in any journal articles containing images produced by w
 citation("PlotFTIR")
 ```
 
+## Language Settings
+
+The package has the ability to change language from English to French for plots on a per-plot basis (call `plot_ftir()` functions with `lang = 'en'` or `lang = 'fr` arguments). In addition, the default language can be set to English or French by setting `options('PlotFTIR.lang' = 'en')` or `options('PlotFTIR.lang' = 'fr')` respectively. This can be added to your .RProfile to persist between R sessions.
+
 ([English](#introduction-and-installation))
 
 ## Introduction et installation
@@ -188,6 +194,8 @@ Vous pouvez installer la version de développement de `PlotFTIR` depuis [GitHub]
 ``` r
 # install.packages("devtools")
 devtools::install_github("NRCan/PlotFTIR")
+
+library(PlotFTIR)
 ```
 
 ## Exemples des tracés
@@ -335,3 +343,7 @@ Veuillez citer ce paquet dans tout article de journal contenant des images produ
 ```{r cite-fr, warning=FALSE}
 citation("PlotFTIR")
 ```
+
+## Paramètres de langue
+
+Le paquetage a la capacité de changer la langue de l'anglais au français pour les tracés sur une base individuelle (appeler les fonctions `plot_ftir()` avec les arguments `lang = 'en'` ou `lang = 'fr'`). De plus, la langue par défaut peut être réglée sur l'anglais ou le français en réglant `options('PlotFTIR.lang' = 'en')` ou `options('PlotFTIR.lang' = 'fr')` respectivement. Ceci peut être ajouté à votre .RProfile pour persister entre les sessions R.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ You can install the development version of `PlotFTIR` from
 ``` r
 # install.packages("devtools")
 devtools::install_github("NRCan/PlotFTIR")
+
+library(PlotFTIR)
 ```
 
 ## Example Plots
@@ -35,7 +37,6 @@ This is a basic example which shows you how to plot a prepared set of
 FTIR spectra:
 
 ``` r
-library(PlotFTIR)
 biodiesel_plot <- plot_ftir(biodiesel)
 biodiesel_plot
 ```
@@ -240,17 +241,27 @@ citation("PlotFTIR")
 #> To cite package 'PlotFTIR' in publications use:
 #> 
 #>   Bulsink P (????). _PlotFTIR: Plot FTIR Spectra_. R package version
-#>   1.0.0, <https://github.com/NRCan/PlotFTIR>.
+#>   1.0.0.9000, <https://github.com/NRCan/PlotFTIR>.
 #> 
 #> A BibTeX entry for LaTeX users is
 #> 
 #>   @Manual{,
 #>     title = {PlotFTIR: Plot FTIR Spectra},
 #>     author = {Philip Bulsink},
-#>     note = {R package version 1.0.0},
+#>     note = {R package version 1.0.0.9000},
 #>     url = {https://github.com/NRCan/PlotFTIR},
 #>   }
 ```
+
+## Language Settings
+
+The package has the ability to change language from English to French
+for plots on a per-plot basis (call `plot_ftir()` functions with
+`lang = 'en'` or `lang = 'fr` arguments). In addition, the default
+language can be set to English or French by setting
+`options('PlotFTIR.lang' = 'en')` or `options('PlotFTIR.lang' = 'fr')`
+respectively. This can be added to your .RProfile to persist between R
+sessions.
 
 ([English](#introduction-and-installation))
 
@@ -268,6 +279,8 @@ Vous pouvez installer la version de développement de `PlotFTIR` depuis
 ``` r
 # install.packages("devtools")
 devtools::install_github("NRCan/PlotFTIR")
+
+library(PlotFTIR)
 ```
 
 ## Exemples des tracés
@@ -494,14 +507,24 @@ citation("PlotFTIR")
 #> To cite package 'PlotFTIR' in publications use:
 #> 
 #>   Bulsink P (????). _PlotFTIR: Plot FTIR Spectra_. R package version
-#>   1.0.0, <https://github.com/NRCan/PlotFTIR>.
+#>   1.0.0.9000, <https://github.com/NRCan/PlotFTIR>.
 #> 
 #> A BibTeX entry for LaTeX users is
 #> 
 #>   @Manual{,
 #>     title = {PlotFTIR: Plot FTIR Spectra},
 #>     author = {Philip Bulsink},
-#>     note = {R package version 1.0.0},
+#>     note = {R package version 1.0.0.9000},
 #>     url = {https://github.com/NRCan/PlotFTIR},
 #>   }
 ```
+
+## Paramètres de langue
+
+Le paquetage a la capacité de changer la langue de l’anglais au français
+pour les tracés sur une base individuelle (appeler les fonctions
+`plot_ftir()` avec les arguments `lang = 'en'` ou `lang = 'fr'`). De
+plus, la langue par défaut peut être réglée sur l’anglais ou le français
+en réglant `options('PlotFTIR.lang' = 'en')` ou
+`options('PlotFTIR.lang' = 'fr')` respectivement. Ceci peut être ajouté
+à votre .RProfile pour persister entre les sessions R.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,20 +1,6 @@
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors | 0 warnings | 0 notes
 
-* This is a new release.
-
-* Previously resubmitted with corrections made as requested by Uwe Ligges:
-   * package names in description surrounded by a single quote,
-   * with CODE_OF_CONDUCT.md references removed from readme,
-   * file LICENSE removed and 'cph' specified in Authors@R
-   
-* Previously resubmitted with corrections made as requested by Konstanze Lauseker:
-   * Examples with \dontrun are unwrapped and (if required) wrapped by requireNamespace() checks.
-   * At this point no external references to these methods exist, so no change to DESCRIPTION has been made. 
-   
-* This is a resubmission with changes made as requested by Beni Altmann:
-   * Changes to working directory were unavoidable by the interface to ChemoSpec (that package doesn't allow
-   for specifying directory when importing files). As such, in-code changes to working directory are protected
-   with a call to `on.exit()`. 
-   * This resubmit also adds a function for normalization of spectra per user request (in maths.R), with associated docs.
+* This is a minor update with improvements
+  * Added ability to set default language in options().

--- a/man/plot_ftir.Rd
+++ b/man/plot_ftir.Rd
@@ -8,7 +8,7 @@ plot_ftir(
   ftir,
   plot_title = "FTIR Spectra",
   legend_title = "Sample ID",
-  lang = "en"
+  lang = NA
 )
 }
 \arguments{
@@ -36,13 +36,20 @@ plot_ftir(
 \item{lang}{An optional argument for language. If set to one of `fr`,
   `french`, `francais`, or `français` the axis and default plot and legend
   titles will change to french. If non-default legend or plot titles are
-  provided they are used as-is. Can also provide `en`, `english` or
-  `anglais`.
+  provided they are used as-is. You can also provide `en`, `english` or
+  `anglais`, or (the default) `NA` will use the default language from user
+  options. To set a permanent default, set `options("PlotFTIR.lang" = "en")`
+  or `options("PlotFTIR.lang" = "fr")` for English or French, respectively.
 
   Un argument optionnel pour la langue. S'il vaut `Fr`, `French`, `Francais`,
   ou `Français`, l'axe et les titres par défaut de le tracé et du légende
   seront en français. Si des titres du légende ou de tracé autres que ceux
-  par défaut sont fournis, ils seront utilisés tels quels.}
+  par défaut sont fournis, ils seront utilisés tels quels. Vous pouvez aussi
+  fournir `en`, `english` ou `anglais`, ou (le défaut) `NA` qui utilisera le
+  langue par défaut des options de l'utilisateur. Pour définir une valeur
+  par défaut permanente, mettez `options("PlotFTIR.lang" = "en")` ou
+  `options("PlotFTIR.lang" = "fr")` pour l'anglais ou le français,
+  respectivement.}
 }
 \value{
 a ggplot object containing a  FTIR spectral plot. The plot and legend

--- a/man/plot_ftir_core.Rd
+++ b/man/plot_ftir_core.Rd
@@ -8,7 +8,7 @@ plot_ftir_core(
   ftir,
   plot_title = "FTIR Spectra",
   legend_title = "Sample ID",
-  lang = "en"
+  lang = NA
 )
 }
 \arguments{
@@ -36,13 +36,20 @@ plot_ftir_core(
 \item{lang}{An optional argument for language. If set to one of `fr`,
   `french`, `francais`, or `français` the axis and default plot and legend
   titles will change to french. If non-default legend or plot titles are
-  provided they are used as-is. Can also provide `en`, `english` or
-  `anglais`.
+  provided they are used as-is. You can also provide `en`, `english` or
+  `anglais`, or (the default) `NA` will use the default language from user
+  options. To set a permanent default, set `options("PlotFTIR.lang" = "en")`
+  or `options("PlotFTIR.lang" = "fr")` for English or French, respectively.
 
   Un argument optionnel pour la langue. S'il vaut `Fr`, `French`, `Francais`,
   ou `Français`, l'axe et les titres par défaut de le tracé et du légende
   seront en français. Si des titres du légende ou de tracé autres que ceux
-  par défaut sont fournis, ils seront utilisés tels quels.}
+  par défaut sont fournis, ils seront utilisés tels quels. Vous pouvez aussi
+  fournir `en`, `english` ou `anglais`, ou (le défaut) `NA` qui utilisera le
+  langue par défaut des options de l'utilisateur. Pour définir une valeur
+  par défaut permanente, mettez `options("PlotFTIR.lang" = "en")` ou
+  `options("PlotFTIR.lang" = "fr")` pour l'anglais ou le français,
+  respectivement.}
 }
 \value{
 a ggplot object containing a  FTIR spectral plot. The plot and legend

--- a/man/plot_ftir_stacked.Rd
+++ b/man/plot_ftir_stacked.Rd
@@ -9,7 +9,7 @@ plot_ftir_stacked(
   plot_title = "FTIR Spectra",
   legend_title = "Sample ID",
   stack_offset = 10,
-  lang = "en"
+  lang = NA
 )
 }
 \arguments{
@@ -45,13 +45,20 @@ plot_ftir_stacked(
 \item{lang}{An optional argument for language. If set to one of `fr`,
   `french`, `francais`, or `français` the axis and default plot and legend
   titles will change to french. If non-default legend or plot titles are
-  provided they are used as-is. Can also provide `en`, `english` or
-  `anglais`.
+  provided they are used as-is. You can also provide `en`, `english` or
+  `anglais`, or (the default) `NA` will use the default language from user
+  options. To set a permanent default, set `options("PlotFTIR.lang" = "en")`
+  or `options("PlotFTIR.lang" = "fr")` for English or French, respectively.
 
   Un argument optionnel pour la langue. S'il vaut `Fr`, `French`, `Francais`,
   ou `Français`, l'axe et les titres par défaut de le tracé et du légende
   seront en français. Si des titres du légende ou de tracé autres que ceux
-  par défaut sont fournis, ils seront utilisés tels quels.}
+  par défaut sont fournis, ils seront utilisés tels quels. Vous pouvez aussi
+  fournir `en`, `english` ou `anglais`, ou (le défaut) `NA` qui utilisera le
+  langue par défaut des options de l'utilisateur. Pour définir une valeur
+  par défaut permanente, mettez `options("PlotFTIR.lang" = "en")` ou
+  `options("PlotFTIR.lang" = "fr")` pour l'anglais ou le français,
+  respectivement.}
 }
 \value{
 a ggplot object containing a  FTIR spectral plot. The plot and legend


### PR DESCRIPTION
Keeps functionality of language setting by plot, but adds default option to simplify (particularly for French users).

Closes #10 