### PR TITLE
Fix ir sample ID handling in conversion #35

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * `print()` now provides pretty printing for PlotFTIR data structures, showing spectral range, resolution, intensity type, number of samples, and sample IDs. ([#27](https://github.com/NRCan/PlotFTIR/issues/27))
 * Updated to use `ggplot2::coord_transform()` instead of `coord_trans`, which is now deprecated. ([#25](https://github.com/NRCan/PlotFTIR/issues/25))
-* Resolved issue with data exchange with `ir` package ([#35](https://github.com/NRCan/PlotFTIR/issues/35))
+* Resolved issue with data exchange with `ir` package. ([#35](https://github.com/NRCan/PlotFTIR/issues/35))
 
 # PlotFTIR 1.2.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # PlotFTIR (development version)
 
-* `print()` now provides pretty printing for PlotFTIR data structures, showing spectral range, resolution, intensity type, number of samples, and sample IDs. (#27)
-* Updated to use `ggplot2::coord_transform()` instead of `coord_trans`, which is now deprecated. (#25)
+* `print()` now provides pretty printing for PlotFTIR data structures, showing spectral range, resolution, intensity type, number of samples, and sample IDs. ([#27](https://github.com/NRCan/PlotFTIR/issues/27))
+* Updated to use `ggplot2::coord_transform()` instead of `coord_trans`, which is now deprecated. ([#25](https://github.com/NRCan/PlotFTIR/issues/25))
+* Resolved issue with data exchange with `ir` package ([#35](https://github.com/NRCan/PlotFTIR/issues/35))
 
 # PlotFTIR 1.2.1
 

--- a/R/io.R
+++ b/R/io.R
@@ -614,7 +614,17 @@ ir_to_df <- function(ir, what) {
   }
 
   irdata <- ir::ir_get_spectrum(ir, what = what)
-  irdata <- mapply(cbind, irdata, "sample_id" = names(irdata), SIMPLIFY = FALSE)
+  if(!is.null(names(irdata))) {
+    sample_ids <- names(irdata)
+  } else if('id_sample' %in% names(ir)){
+    sample_ids <- as.vector(ir$id_sample[what])
+  } else {
+    cli::cli_warn(
+      "Could not find sample spectra ids from {.pkg ir} object.",
+      call = rlang::caller_fn()
+    )
+  }
+  irdata <- mapply(cbind, irdata, "sample_id" = sample_ids, SIMPLIFY = FALSE)
   irdata <- do.call(rbind, irdata)
   colnames(irdata)[colnames(irdata) == "x"] <- "wavenumber"
 

--- a/R/io.R
+++ b/R/io.R
@@ -621,8 +621,10 @@ ir_to_df <- function(ir, what) {
   } else {
     cli::cli_warn(
       "Could not find sample spectra ids from {.pkg ir} object.",
+      i = "Sample IDs assigned index numerical values.",
       call = rlang::caller_fn()
     )
+    sample_ids <- as.vector(as.character(what))
   }
   irdata <- mapply(cbind, irdata, "sample_id" = sample_ids, SIMPLIFY = FALSE)
   irdata <- do.call(rbind, irdata)

--- a/tests/testthat/test-io.R
+++ b/tests/testthat/test-io.R
@@ -531,6 +531,18 @@ test_that("interface to ir is ok for PlotFTIR data (#35)", {
 
   expect_true("PlotFTIR_data" %in% class(adjusted_bd))
   expect_setequal(unique(adjusted_bd$sample_id), unique(biodiesel$sample_id))
+
+  adjusted_2 <- plotftir_to_ir(biodiesel, metadata = NA) |>
+    ir::ir_bc(method = "rubberband", return_bl = FALSE)
+
+  adjusted_2$id_sample <- NULL
+
+  expect_warning(adjusted_2 <- ir_to_plotftir(ir_data = adjusted_2, what = c(1,2,4)),
+    regexp = "Could not find sample spectra ids from",
+    fixed = TRUE)
+
+  expect_equal(unique(adjusted_2$sample_id), as.character(c(1,2,4)))
+
 })
 
 test_that("Interface to ChemoSpec is ok", {

--- a/tests/testthat/test-io.R
+++ b/tests/testthat/test-io.R
@@ -520,6 +520,15 @@ test_that("interface to ir is ok", {
   expect_true("ggplot" %in% suppressWarnings(class(plot_ftir(irdata))))
 })
 
+test_that("Interface to IR is ok for PlotFTIR data (# 35)",{
+  adjusted_BD <- plotftir_to_ir(biodiesel, metadata = NA) |>
+    ir::ir_bc(method = "rubberband", return_bl = FALSE) |>
+    ir_to_plotftir(what=NA)
+
+  expect_equal(names(adjusted_BD), names(biodiesel))
+  
+})
+
 test_that("Interface to ChemoSpec is ok", {
   if (!requireNamespace("R.utils", quietly = TRUE)) {
     expect_error(

--- a/tests/testthat/test-io.R
+++ b/tests/testthat/test-io.R
@@ -520,13 +520,17 @@ test_that("interface to ir is ok", {
   expect_true("ggplot" %in% suppressWarnings(class(plot_ftir(irdata))))
 })
 
-test_that("Interface to IR is ok for PlotFTIR data (# 35)",{
-  adjusted_BD <- plotftir_to_ir(biodiesel, metadata = NA) |>
-    ir::ir_bc(method = "rubberband", return_bl = FALSE) |>
-    ir_to_plotftir(what=NA)
+test_that("interface to ir is ok for PlotFTIR data (#35)", {
+  if (!requireNamespace("ir", quietly = TRUE)) {
+    testthat::skip("ir not available for testing interface")
+  }
 
-  expect_equal(names(adjusted_BD), names(biodiesel))
-  
+  adjusted_bd <- plotftir_to_ir(biodiesel, metadata = NA) |>
+    ir::ir_bc(method = "rubberband", return_bl = FALSE) |>
+    ir_to_plotftir(what = NA)
+
+  expect_true("PlotFTIR_data" %in% class(adjusted_bd))
+  expect_setequal(unique(adjusted_bd$sample_id), unique(biodiesel$sample_id))
 })
 
 test_that("Interface to ChemoSpec is ok", {


### PR DESCRIPTION
Updates `ir_to_df()` to recover `sample_id` values when `ir_get_spectrum()` output is unnamed by falling back to `ir$id_sample[what]`, with a warning when IDs cannot be found. Adds a regression test for PlotFTIR ↔ ir round-tripping after baseline correction, and updates `NEWS.md` with linked issue references including the `ir` interoperability fix (closes #35).